### PR TITLE
Fix URL path in mixed content samples

### DIFF
--- a/samples/fundamentals/security/prevent-mixed-content/active-mixed-content.html
+++ b/samples/fundamentals/security/prevent-mixed-content/active-mixed-content.html
@@ -14,16 +14,16 @@
     <title>Active mixed content example</title>
     
 <!-- An insecure script file loaded on a secure page -->
-    <script src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/simple-example.js"></script>
+    <script src="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/simple-example.js"></script>
   
     <!-- An insecure stylesheet loaded on a secure page -->
-    <link href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/style.css" rel="stylesheet">
+    <link href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/style.css" rel="stylesheet">
 
     <style>
       .insecure-background {
         /* An insecure resources loaded from a style property on a secure page, this can   
            happen in many places including, @font-face, cursor, background-image, and so on. */
-        background: url('http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy-thumb.jpg') no-repeat;
+        background: url('http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/puppy-thumb.jpg') no-repeat;
       }
     </style>
     
@@ -52,7 +52,7 @@
         Active mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/active-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/active-mixed-content.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/active-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/active-mixed-content.html">HTTPS</a>
       </p>
       <p>
         Several examples of active mixed content. When viewed over HTTPS most browsers block this content and display errors in the JavaScript console.
@@ -67,7 +67,7 @@
       <p>Loading insecure iframe...</p>
       
 <!-- An insecure iframed page loaded on a secure page -->
-      <iframe src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html"></iframe>
+      <iframe src="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/image-gallery-example.html"></iframe>
       
       <!-- Flash resources also qualify as active mixed content and pose a
       serious security risk. Be sure to look for <object> tags with type set
@@ -81,7 +81,7 @@
           var jsonData = JSON.parse(request.responseText);
           document.getElementById('output').innerHTML += '<br>' + jsonData.data;
         });
-        request.open("GET", "http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/xmlhttprequest-data.js", true);
+        request.open("GET", "http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/xmlhttprequest-data.js", true);
         request.send();
       </script>
       

--- a/samples/fundamentals/security/prevent-mixed-content/image-gallery-example.html
+++ b/samples/fundamentals/security/prevent-mixed-content/image-gallery-example.html
@@ -54,15 +54,15 @@
         Image gallery mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/image-gallery-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/image-gallery-example.html">HTTPS</a>
       </p>
       <p> 
         Image galleries often rely on the &lt;img&gt; tag src attribute to display thumbnail images on the page, the anchor ( &lt;a&gt; ) tag href attribute is then used to load the full sized image for the gallery overlay. Normally &lt;a&gt; tags do not cause mixed content, but in this case the jQuery code overrides the default link behavior &mdash; to navigate to a new page &mdash; and instead loads the HTTP image on this page. While this content isn't blocked, modern browsers display a warning in the JavaScript console. This can be seen when the page is viewed over HTTPS and the thumbnail is clicked.
       </p>
       CLICK ME! -->
       
-<a class="gallery" href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy.jpg">
-        <img src="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy-thumb.jpg">
+<a class="gallery" href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/puppy.jpg">
+        <img src="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/puppy-thumb.jpg">
       </a>
       
 <div class="overlay overlay-background" style="display: none;"></div>

--- a/samples/fundamentals/security/prevent-mixed-content/passive-mixed-content.html
+++ b/samples/fundamentals/security/prevent-mixed-content/passive-mixed-content.html
@@ -25,7 +25,7 @@
         Passive mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/passive-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/passive-mixed-content.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/passive-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/passive-mixed-content.html">HTTPS</a>
       </p>
       <p>
         Several examples of passive mixed content. When viewed over HTTPS most browsers do <b>not</b> block this content but instead display warnings in the JavaScript console.
@@ -33,10 +33,10 @@
 
       
 <!-- An insecure audio file loaded on a secure page -->
-      <audio src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/symphony-5-beethoven.mp3" type="audio/mp3" controls></audio>
+      <audio src="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/symphony-5-beethoven.mp3" type="audio/mp3" controls></audio>
 
       <!-- An insecure image loaded on a secure page -->
-      <img src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy.jpg">
+      <img src="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/puppy.jpg">
 
       <!-- An insecure video file loaded on a secure page -->
       <video src="http://developers.google.com/web/fundamentals/media/video/video/chrome.webm" type="video/webm" controls></video>

--- a/samples/fundamentals/security/prevent-mixed-content/simple-example.html
+++ b/samples/fundamentals/security/prevent-mixed-content/simple-example.html
@@ -19,14 +19,14 @@
         Simple mixed content example!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/simple-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/simple-example.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/simple-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/simple-example.html">HTTPS</a>
       </p>
       <p>
         This page loads the script simple-example.js using HTTP. This is the simplest case of mixed content. When the simple-example.js file is requested by the browser, an attacker can inject code into the returned content and take control of the entire page. Thankfully, most modern browsers block this type of dangerous content by default and display an error in the JavaScript console. This can be seen when the page is viewed over HTTPS.
       </p>
       <div id="output">Waiting for insecure script to run...</div>
       
-<script src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/simple-example.js"></script>
+<script src="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/simple-example.js"></script>
       
 </div>
     <script>

--- a/samples/fundamentals/security/prevent-mixed-content/xmlhttprequest-example.html
+++ b/samples/fundamentals/security/prevent-mixed-content/xmlhttprequest-example.html
@@ -19,7 +19,7 @@
         XMLHttpRequest mixed content example!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/xmlhttprequest-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/xmlhttprequest-example.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/xmlhttprequest-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content/xmlhttprequest-example.html">HTTPS</a>
       </p>
       <p>
         This page constructs an HTTP URL dynamically in JavaScript, the URL is eventually used to load an insecure resource by XMLHttpRequest. When the xmlhttprequest-data.js file is requested by the browser, an attacker can inject code into the returned content and take control of the entire page. Thankfully, most modern browsers block this type of dangerous content by default and display an error in the JavaScript console. This can be seen when the page is viewed over HTTPS.
@@ -27,7 +27,7 @@
       <div id="output">Waiting for data...</div>
       
 <script>
-        var rootUrl = 'http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content';
+        var rootUrl = 'http://googlesamples.github.io/web-fundamentals/samples/fundamentals/security/prevent-mixed-content';
         var resources = {
           jsonData: '/xmlhttprequest-data.js'
         };


### PR DESCRIPTION
URLs broken in mixed content samples, I fixed it with a simple replacement, please merge this pull request.
