### PR TITLE
Replace URLs to New Address

### DIFF
--- a/fundamentals/security/prevent-mixed-content/active-mixed-content.html
+++ b/fundamentals/security/prevent-mixed-content/active-mixed-content.html
@@ -15,16 +15,16 @@
     <title>Active mixed content example</title>
     <!-- // [START snippet1] -->
     <!-- An insecure script file loaded on a secure page -->
-    <script src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/simple-example.js"></script>
+    <script src="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/simple-example.js"></script>
   
     <!-- An insecure stylesheet loaded on a secure page -->
-    <link href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/style.css" rel="stylesheet">
+    <link href="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/style.css" rel="stylesheet">
 
     <style>
       .insecure-background {
         /* An insecure resources loaded from a style property on a secure page, this can   
            happen in many places including, @font-face, cursor, background-image, and so on. */
-        background: url('http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy-thumb.jpg') no-repeat;
+        background: url('http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/puppy-thumb.jpg') no-repeat;
       }
     </style>
     <!-- // [END snippet1] -->
@@ -54,7 +54,7 @@
         Active mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/active-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/active-mixed-content.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/active-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/active-mixed-content.html">HTTPS</a>
       </p>
       <p>
         Several examples of active mixed content. When viewed over HTTPS most browsers block this content and display errors in the JavaScript console.
@@ -69,7 +69,7 @@
       <p>Loading insecure iframe...</p>
       <!-- // [START snippet2] -->
       <!-- An insecure iframed page loaded on a secure page -->
-      <iframe src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html"></iframe>
+      <iframe src="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/image-gallery-example.html"></iframe>
       
       <!-- Flash resources also qualify as active mixed content and pose a
       serious security risk. Be sure to look for <object> tags with type set
@@ -83,7 +83,7 @@
           var jsonData = JSON.parse(request.responseText);
           document.getElementById('output').innerHTML += '<br>' + jsonData.data;
         });
-        request.open("GET", "http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/xmlhttprequest-data.js", true);
+        request.open("GET", "http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/xmlhttprequest-data.js", true);
         request.send();
       </script>
       <!-- // [END snippet2] -->

--- a/fundamentals/security/prevent-mixed-content/image-gallery-example.html
+++ b/fundamentals/security/prevent-mixed-content/image-gallery-example.html
@@ -55,15 +55,15 @@
         Image gallery mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/image-gallery-example.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/image-gallery-example.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/image-gallery-example.html">HTTPS</a>
       </p>
       <p> 
         Image galleries often rely on the &lt;img&gt; tag src attribute to display thumbnail images on the page, the anchor ( &lt;a&gt; ) tag href attribute is then used to load the full sized image for the gallery overlay. Normally &lt;a&gt; tags do not cause mixed content, but in this case the jQuery code overrides the default link behavior &mdash; to navigate to a new page &mdash; and instead loads the HTTP image on this page. While this content isn't blocked, modern browsers display a warning in the JavaScript console. This can be seen when the page is viewed over HTTPS and the thumbnail is clicked.
       </p>
       CLICK ME! -->
       <!-- // [START snippet1] -->
-      <a class="gallery" href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy.jpg">
-        <img src="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy-thumb.jpg">
+      <a class="gallery" href="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/puppy.jpg">
+        <img src="https://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/puppy-thumb.jpg">
       </a>
       <!-- // [END snippet1] -->
       <div class="overlay overlay-background" style="display: none;"></div>

--- a/fundamentals/security/prevent-mixed-content/passive-mixed-content.html
+++ b/fundamentals/security/prevent-mixed-content/passive-mixed-content.html
@@ -26,7 +26,7 @@
         Passive mixed content!
       </h1>
       <p>
-        View page over: <a href="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/passive-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/passive-mixed-content.html">HTTPS</a>
+        View page over: <a href="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/passive-mixed-content.html">HTTP</a> - <a href="https://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/passive-mixed-content.html">HTTPS</a>
       </p>
       <p>
         Several examples of passive mixed content. When viewed over HTTPS most browsers do <b>not</b> block this content but instead display warnings in the JavaScript console.
@@ -34,10 +34,10 @@
 
       <!-- // [START snippet1] -->
       <!-- An insecure audio file loaded on a secure page -->
-      <audio src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/sleep.mp3" type="audio/mp3" controls></audio>
+      <audio src="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/sleep.mp3" type="audio/mp3" controls></audio>
 
       <!-- An insecure image loaded on a secure page -->
-      <img src="http://googlesamples.github.io/web-fundamentals/samples/discovery-and-distribution/avoid-mixed-content/puppy.jpg">
+      <img src="http://googlesamples.github.io/web-fundamentals/fundamentals/security/prevent-mixed-content/puppy.jpg">
 
       <!-- An insecure video file loaded on a secure page -->
       <video src="http://storage.googleapis.com/webfundamentals-assets/videos/chrome.webm" type="video/webm" controls></video>


### PR DESCRIPTION
I fixed the web-fundamentals security pages by replacing the URLs pointing to an old address to the correct address.

I don't think this worked since it was published a few years ago!